### PR TITLE
feat(cli): implement init command #3

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -22,10 +22,12 @@
     "yargs": "^17.7.2"
   },
   "devDependencies": {
+    "@types/mock-fs": "^4.13.4",
     "@types/node": "^22.15.3",
     "@types/yargs": "^17.0.33",
     "@vitest/coverage-v8": "^3.1.3",
     "execa": "^9.5.2",
+    "mock-fs": "^5.5.0",
     "tsup": "^8.4.0",
     "typescript": "^5.8.3",
     "vitest": "^3.1.2"

--- a/packages/cli/src/commands/init.test.ts
+++ b/packages/cli/src/commands/init.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, beforeEach, afterEach, expect } from "vitest";
+import { existsSync, readFileSync, mkdirSync, writeFileSync } from "fs";
+import { join } from "path";
+import mock from "mock-fs";
+import { runInit } from "./init";
+
+describe("work-journal init command", () => {
+  const mockSourceTemplatesPath = "/mock/source-templates";
+  const mockDestTemplatesPath = "/mock/dest-templates";
+
+  beforeEach(() => {
+    mock({
+      [mockSourceTemplatesPath]: {
+        "daily.md": "Daily template content",
+        "weekly.md": "Weekly template content",
+        config: { "settings.json": "some settings" },
+      },
+      "/mock": {},
+    });
+  });
+
+  afterEach(() => {
+    mock.restore();
+  });
+
+  it("should create templates directory and copy files if it does not exist", () => {
+    expect(existsSync(mockDestTemplatesPath)).toBe(false);
+
+    runInit(false, mockDestTemplatesPath, mockSourceTemplatesPath);
+
+    expect(existsSync(mockDestTemplatesPath)).toBe(true);
+    expect(existsSync(join(mockDestTemplatesPath, "daily.md"))).toBe(true);
+    expect(readFileSync(join(mockDestTemplatesPath, "daily.md"), "utf8")).toBe("Daily template content");
+    expect(existsSync(join(mockDestTemplatesPath, "weekly.md"))).toBe(true);
+    expect(readFileSync(join(mockDestTemplatesPath, "weekly.md"), "utf8")).toBe("Weekly template content");
+    expect(existsSync(join(mockDestTemplatesPath, "config"))).toBe(false);
+  });
+
+  it("should throw error if templates directory exists and --force is not used", () => {
+    mkdirSync(mockDestTemplatesPath, { recursive: true });
+    writeFileSync(join(mockDestTemplatesPath, "dummy.txt"), "existing content");
+    expect(existsSync(mockDestTemplatesPath)).toBe(true);
+
+    expect(() => runInit(false, mockDestTemplatesPath, mockSourceTemplatesPath)).toThrowError(
+      "templates/ already exists – use --force to overwrite"
+    );
+
+    expect(existsSync(join(mockDestTemplatesPath, "dummy.txt"))).toBe(true);
+    expect(readFileSync(join(mockDestTemplatesPath, "dummy.txt"), "utf8")).toBe("existing content");
+    expect(existsSync(join(mockDestTemplatesPath, "daily.md"))).toBe(false);
+    expect(existsSync(join(mockDestTemplatesPath, "weekly.md"))).toBe(false);
+  });
+
+  it("should overwrite existing templates directory if --force is used", () => {
+    mkdirSync(mockDestTemplatesPath, { recursive: true });
+    writeFileSync(join(mockDestTemplatesPath, "dummy.txt"), "existing content");
+    expect(existsSync(mockDestTemplatesPath)).toBe(true);
+
+    runInit(true, mockDestTemplatesPath, mockSourceTemplatesPath);
+
+    expect(existsSync(mockDestTemplatesPath)).toBe(true);
+    expect(existsSync(join(mockDestTemplatesPath, "dummy.txt"))).toBe(true);
+    expect(readFileSync(join(mockDestTemplatesPath, "dummy.txt"), "utf8")).toBe("existing content");
+
+    expect(existsSync(join(mockDestTemplatesPath, "daily.md"))).toBe(true);
+    expect(readFileSync(join(mockDestTemplatesPath, "daily.md"), "utf8")).toBe("Daily template content");
+    expect(existsSync(join(mockDestTemplatesPath, "weekly.md"))).toBe(true);
+    expect(readFileSync(join(mockDestTemplatesPath, "weekly.md"), "utf8")).toBe("Weekly template content");
+    expect(existsSync(join(mockDestTemplatesPath, "config"))).toBe(false);
+  });
+
+  it("should throw error if source directory does not exist", () => {
+    const nonExistentSourcePath = "/mock/non-existent-source";
+    expect(existsSync(nonExistentSourcePath)).toBe(false);
+
+    expect(() => runInit(false, mockDestTemplatesPath, nonExistentSourcePath)).toThrowError(
+      `Source templates directory not found: ${nonExistentSourcePath}`
+    );
+  });
+});

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -1,0 +1,49 @@
+import { mkdirSync, copyFileSync, readdirSync, existsSync, statSync } from "fs";
+import { join } from "path";
+import type { CommandModule } from "yargs";
+import { packageTemplatesDir } from "../lib/pathHelpers";
+
+export function runInit(force: boolean, destDir: string, sourceDir: string): void {
+  if (existsSync(destDir) && !force) {
+    throw new Error("templates/ already exists – use --force to overwrite");
+  }
+  if (!existsSync(sourceDir)) {
+    throw new Error(`Source templates directory not found: ${sourceDir}`);
+  }
+
+  mkdirSync(destDir, { recursive: true });
+  for (const f of readdirSync(sourceDir)) {
+    const sourceFile = join(sourceDir, f);
+    if (existsSync(sourceFile) && statSync(sourceFile).isFile()) {
+      copyFileSync(sourceFile, join(destDir, f));
+    } else if (!existsSync(sourceFile)) {
+      console.warn(`Warning: Source template file not found: ${sourceFile}`);
+    }
+  }
+}
+
+interface InitArgs {
+  force: boolean;
+}
+
+export const initCommand: CommandModule<{}, InitArgs> = {
+  command: "init",
+  describe: "seed templates in ./templates",
+  builder: (yargs) =>
+    yargs.option("force", {
+      type: "boolean",
+      default: false,
+      describe: "Overwrite existing templates directory",
+    }),
+  handler: ({ force }) => {
+    const dest = join(process.cwd(), "templates");
+    try {
+      const source = packageTemplatesDir();
+      runInit(force, dest, source);
+      console.log("✅ templates/ ready – hack away!");
+    } catch (error: any) {
+      console.error(`Error: ${error.message}`);
+      process.exit(1);
+    }
+  },
+};

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -6,7 +6,6 @@ import { initCommand } from "./commands/init"; // Import the init command module
 yargs(hideBin(process.argv)) // Use hideBin here
   .scriptName("work-journal")
   .command(initCommand) // Register the init command module
-  // .command("placeholder", "A placeholder command for now") // Remove placeholder
   .demandCommand(1, "Please specify a command.") // Update demandCommand message
   .strict() // Enable strict mode
   .help()

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,8 +1,13 @@
 #!/usr/bin/env node
 import yargs from "yargs";
-yargs()
+import { hideBin } from "yargs/helpers"; // Import hideBin
+import { initCommand } from "./commands/init"; // Import the init command module
+
+yargs(hideBin(process.argv)) // Use hideBin here
   .scriptName("work-journal")
-  .command("placeholder", "A placeholder command for now")
-  .demandCommand()
+  .command(initCommand) // Register the init command module
+  // .command("placeholder", "A placeholder command for now") // Remove placeholder
+  .demandCommand(1, "Please specify a command.") // Update demandCommand message
+  .strict() // Enable strict mode
   .help()
   .parse();

--- a/packages/cli/src/lib/pathHelpers.ts
+++ b/packages/cli/src/lib/pathHelpers.ts
@@ -33,7 +33,7 @@ export function packageTemplatesDir(): string {
     return join(currentFilePath, "..", "..", "templates");
   } catch (e) {
     // Fallback for CJS context
-    // Needs to go up from lib -> src -> packages/cli -> templates
-    return join(__dirname, "..", "..", "templates");
+    // Needs to go up from lib -> src -> cli -> packages -> templates
+    return join(__dirname, "..", "..", "..", "..", "templates");
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,6 +24,9 @@ importers:
         specifier: ^17.7.2
         version: 17.7.2
     devDependencies:
+      '@types/mock-fs':
+        specifier: ^4.13.4
+        version: 4.13.4
       '@types/node':
         specifier: ^22.15.3
         version: 22.15.3
@@ -36,6 +39,9 @@ importers:
       execa:
         specifier: ^9.5.2
         version: 9.5.2
+      mock-fs:
+        specifier: ^5.5.0
+        version: 5.5.0
       tsup:
         specifier: ^8.4.0
         version: 8.4.0(postcss@8.5.3)(typescript@5.8.3)
@@ -363,6 +369,9 @@ packages:
   '@types/estree@1.0.7':
     resolution: {integrity: sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ==}
 
+  '@types/mock-fs@4.13.4':
+    resolution: {integrity: sha512-mXmM0o6lULPI8z3XNnQCpL0BGxPwx1Ul1wXYEPBGl4efShyxW2Rln0JOPEWGyZaYZMM6OVXM/15zUuFMY52ljg==}
+
   '@types/node@22.15.3':
     resolution: {integrity: sha512-lX7HFZeHf4QG/J7tBZqrCAXwz9J5RD56Y6MpP0eJkka8p+K0RY/yBTW7CYFJ4VGCclxqOLKmiGP5juQc6MKgcw==}
 
@@ -655,6 +664,10 @@ packages:
   minipass@7.1.2:
     resolution: {integrity: sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==}
     engines: {node: '>=16 || 14 >=14.17'}
+
+  mock-fs@5.5.0:
+    resolution: {integrity: sha512-d/P1M/RacgM3dB0sJ8rjeRNXxtapkPCUnMGmIN0ixJ16F/E4GUZCvWcSGfWGz8eaXYvn1s9baUwNjI4LOPEjiA==}
+    engines: {node: '>=12.0.0'}
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
@@ -1203,6 +1216,10 @@ snapshots:
 
   '@types/estree@1.0.7': {}
 
+  '@types/mock-fs@4.13.4':
+    dependencies:
+      '@types/node': 22.15.3
+
   '@types/node@22.15.3':
     dependencies:
       undici-types: 6.21.0
@@ -1509,6 +1526,8 @@ snapshots:
       brace-expansion: 2.0.1
 
   minipass@7.1.2: {}
+
+  mock-fs@5.5.0: {}
 
   ms@2.1.3: {}
 


### PR DESCRIPTION
- Adds 'work-journal init' command to copy default templates.\n- Creates templates/ directory in the current working directory.\n- Uses --force to overwrite existing directory.\n- Includes unit tests with mock-fs.\n- Refactors command logic for testability.\n- Closes #3
