### PR TITLE
Fix CI workflow using pnpm/action-setup (Option B)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,16 +18,19 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # 1️⃣ Install pnpm first (without caching)
+      - uses: pnpm/action-setup@v3
+        with:
+          version: 10.10.0
+          run_install: false
+
+      # 2️⃣ Then set up Node.js with pnpm caching
       - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node }}
-          cache: pnpm # still grabs the store from previous runs
+          cache: "pnpm"
 
-      - uses: pnpm/action-setup@v3
-        with:
-          version: 10.10.0 # matches the version in package.json
-          run_install: false # we'll call pnpm install ourselves
-
+      # 3️⃣ Now run the normal workflow
       - run: pnpm install --frozen-lockfile
       - run: pnpm -r run build
       - run: pnpm test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,20 +17,15 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-
-      # 1️⃣ Install pnpm first (without caching)
       - uses: pnpm/action-setup@v3
         with:
           version: 10.10.0
           run_install: false
-
-      # 2️⃣ Then set up Node.js with pnpm caching
       - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node }}
-          cache: "pnpm"
-
-      # 3️⃣ Now run the normal workflow
+          cache: pnpm
+          cache-dependency-path: "**/pnpm-lock.yaml"
       - run: pnpm install --frozen-lockfile
       - run: pnpm -r run build
       - run: pnpm test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,13 +18,16 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Node & pnpm
-        uses: actions/setup-node@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node }}
-          cache: pnpm # automatic pnpm store caching
+          cache: pnpm # still grabs the store from previous runs
 
-      - run: corepack enable # makes the repo-pinned pnpm available
+      - uses: pnpm/action-setup@v3
+        with:
+          version: 10.10.0 # matches the version in package.json
+          run_install: false # we'll call pnpm install ourselves
+
       - run: pnpm install --frozen-lockfile
       - run: pnpm -r run build
       - run: pnpm test


### PR DESCRIPTION
## Description

This PR fixes the CI workflow by properly setting up pnpm and caching.

The previous workflow was trying to use `corepack` for pnpm, but that was failing. I then updated it to use `pnpm/action-setup`, but there was still an issue with caching. The final solution correctly orders the steps:

1. First install pnpm with `pnpm/action-setup`
2. Then set up Node.js with pnpm caching via `actions/setup-node`
3. Finally run the pnpm commands

## Changes

- Removed the `corepack enable` step that was failing
- Added proper installation order: pnpm first, then Node.js with caching
- Followed the recommended approach from the pnpm/action-setup documentation

## Testing

- Verified locally with `pnpm install --frozen-lockfile && pnpm -r run build && pnpm test`
- The CI workflow should now pass on all platforms and Node versions
- Caching should be properly restored and saved between runs

Closes #27
