### PR TITLE
Fix: Template path resolution broken in production builds

### DIFF
--- a/.changeset/work-journal-patch-20250511-7fed.md
+++ b/.changeset/work-journal-patch-20250511-7fed.md
@@ -1,0 +1,5 @@
+---
+"work-journal": patch
+---
+
+Fix template path resolution broken in production builds

--- a/packages/cli/src/lib/__runtime__/packageTemplatesDir.runtime.test.ts
+++ b/packages/cli/src/lib/__runtime__/packageTemplatesDir.runtime.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from "vitest";
+import { join } from "node:path";
+import { existsSync } from "node:fs";
+import { packageTemplatesDir } from "../pathHelpers"; // compiled code in tests
+
+describe("packageTemplatesDir [runtime]", () => {
+  it("resolves to a valid templates folder with template files", () => {
+    const dir = packageTemplatesDir();
+    // The path can be either:
+    // 1. In node_modules (production/installed environment)
+    // 2. In the local development path (during testing)
+    const isValidPath =
+      dir.match(/node_modules[\\/](.*)work-journal[\\/]templates$/) !== null ||
+      dir.match(/WorkJournal[\\/]packages[\\/]cli[\\/]templates$/) !== null;
+
+    expect(isValidPath).toBe(true);
+    expect(existsSync(join(dir, "daily_template.md"))).toBe(true);
+  });
+});

--- a/packages/cli/src/lib/pathHelpers.ts
+++ b/packages/cli/src/lib/pathHelpers.ts
@@ -48,8 +48,8 @@ export function packageTemplatesDir(): string {
       const dirOfThisFile = dirname(fileURLToPath(import.meta.url)); // dist/lib
       return join(dirOfThisFile, "..", "..", "templates"); // dist/../.. = package root
     } catch (e) {
-      // Final fallback: two levels up from the compiled file
-      return join(__dirname, "..", "..", "templates");
+      // Final fallback: one level up from the compiled file to find templates directory
+      return join(__dirname, "..", "templates");
     }
   }
 


### PR DESCRIPTION
This PR fixes the issue where the templates cannot be found in production. Closes #35