### PR TITLE
fix: case-insensitive template folder lookup with error handling

### DIFF
--- a/.changeset/work-journal-patch-20250519-0f7e.md
+++ b/.changeset/work-journal-patch-20250519-0f7e.md
@@ -1,0 +1,5 @@
+---
+"work-journal": patch
+---
+
+🐛 fix: detect duplicate templates/ and Templates/ folders and provide helpful error

--- a/README.md
+++ b/README.md
@@ -106,6 +106,8 @@ Hit <kbd>⌘⇧B</kbd> (or your build key) and the file opens ready for typing.
 └───────────────┘     └────────────────────────┘     └────────────────────────┘
 ```
 
+Template folder lookup is case-sensitive. While both `templates/` and `Templates/` are supported, the lowercase version is the canonical form and recommended. Using `Templates/` will display a warning. Having both folders simultaneously will trigger an error.
+
 ## Configuration Examples
 
 ```bash

--- a/packages/cli/src/lib/__tests__/pathHelpers.duplicate.test.ts
+++ b/packages/cli/src/lib/__tests__/pathHelpers.duplicate.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { join } from "path";
+import * as fs from "fs";
+import * as pathHelpers from "../pathHelpers";
+
+// Mock modules
+vi.mock("fs");
+
+describe("duplicate templates folder handling", () => {
+  const root = "/repo";
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+
+    // Mock process.cwd
+    vi.stubGlobal("process", {
+      ...process,
+      cwd: vi.fn().mockReturnValue(root),
+    });
+  });
+
+  function mockFs({ lower, upper }: { lower?: boolean; upper?: boolean }) {
+    vi.mocked(fs.existsSync).mockImplementation((p) => {
+      if (lower && p === join(root, "templates")) return true;
+      if (upper && p === join(root, "Templates")) return true;
+      return false;
+    });
+
+    vi.mocked(fs.statSync).mockImplementation(
+      (p) =>
+        ({
+          isDirectory: () => true,
+        } as unknown as fs.Stats)
+    );
+  }
+
+  it("uses lowercase when only it exists", () => {
+    mockFs({ lower: true });
+    expect(pathHelpers.projectTemplatesDir()).toBe(join(root, "templates"));
+  });
+
+  it("warns and uses PascalCase when only it exists", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    mockFs({ upper: true });
+    expect(pathHelpers.projectTemplatesDir()).toBe(join(root, "Templates"));
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining("non-canonical"));
+    warn.mockRestore();
+  });
+
+  it("throws when both exist", () => {
+    mockFs({ lower: true, upper: true });
+    expect(() => pathHelpers.projectTemplatesDir()).toThrow("ERR_DUPLICATE_TEMPLATES_DIR");
+  });
+
+  if (process.platform !== "win32") {
+    // Test Linux-only case-sensitive functionality
+    it("maintains case sensitivity behavior on Linux", () => {
+      mockFs({ lower: true, upper: true });
+      expect(() => pathHelpers.projectTemplatesDir()).toThrow("ERR_DUPLICATE_TEMPLATES_DIR");
+    });
+  }
+});

--- a/packages/cli/src/lib/__tests__/paths.test.ts
+++ b/packages/cli/src/lib/__tests__/paths.test.ts
@@ -9,6 +9,9 @@ vi.mock("../pathHelpers", () => ({
   userTemplatesDir: vi.fn(),
 }));
 
+// Define constants used in tests
+const MOCK_CWD = "/fallback";
+
 describe("resolveScope", () => {
   beforeEach(() => {
     vi.resetAllMocks();
@@ -47,5 +50,48 @@ describe("resolveScope", () => {
     });
 
     process.cwd = originalCwd;
+  });
+
+  describe("error handling with duplicate templates directories", () => {
+    beforeEach(() => {
+      // Restore console.error to prevent test pollution
+      console.error = vi.fn();
+    });
+
+    it("should handle ERR_DUPLICATE_TEMPLATES_DIR error gracefully", () => {
+      // Mock process.cwd to control the return path
+      const originalCwd = process.cwd;
+      process.cwd = vi.fn().mockReturnValue(MOCK_CWD);
+
+      // Mock projectTemplatesDir to throw a duplicate templates error
+      vi.mocked(projectTemplatesDir).mockImplementation(() => {
+        throw new Error("ERR_DUPLICATE_TEMPLATES_DIR: Both 'templates/' and 'Templates/' exist");
+      });
+
+      // resolveScope should not throw the error but handle it
+      const paths = resolveScope(false);
+
+      // Should fallback to CWD
+      expect(paths.templates).toBe(path.join(MOCK_CWD, "templates"));
+      expect(paths.configFile).toBe(path.join(MOCK_CWD, "work-journal.json"));
+
+      // Should log the error
+      expect(console.error).toHaveBeenCalledWith(expect.stringContaining("ERR_DUPLICATE_TEMPLATES_DIR"));
+
+      // Restore original cwd
+      process.cwd = originalCwd;
+    });
+
+    it("should handle Templates (uppercase) path", () => {
+      // Mock projectTemplatesDir to return Templates with uppercase
+      const templatesPath = path.join(MOCK_CWD, "Templates");
+      vi.mocked(projectTemplatesDir).mockReturnValue(templatesPath);
+
+      const paths = resolveScope(false);
+
+      // Should still use lowercase templates for the output path
+      expect(paths.templates).toBe(path.join(MOCK_CWD, "templates"));
+      expect(paths.configFile).toBe(path.join(MOCK_CWD, "work-journal.json"));
+    });
   });
 });

--- a/packages/cli/src/lib/pathHelpers.ts
+++ b/packages/cli/src/lib/pathHelpers.ts
@@ -12,9 +12,28 @@ export function projectTemplatesDir(): string | null {
   const MAX_DEPTH = 50;
 
   while (true) {
-    const templatesPath = join(dir, "templates");
-    if (existsSync(templatesPath) && statSync(templatesPath).isDirectory()) {
-      return templatesPath;
+    const lowerCaseTemplatesPath = join(dir, "templates");
+    const upperCaseTemplatesPath = join(dir, "Templates");
+
+    const lowerCaseExists = existsSync(lowerCaseTemplatesPath) && statSync(lowerCaseTemplatesPath).isDirectory();
+    const upperCaseExists = existsSync(upperCaseTemplatesPath) && statSync(upperCaseTemplatesPath).isDirectory();
+
+    // If both template directories exist, throw an error
+    if (lowerCaseExists && upperCaseExists) {
+      throw new Error(
+        "ERR_DUPLICATE_TEMPLATES_DIR: Both 'templates/' and 'Templates/' exist. Please keep exactly one (lower-case is recommended)."
+      );
+    }
+
+    // Prefer lowercase "templates" if it exists
+    if (lowerCaseExists) {
+      return lowerCaseTemplatesPath;
+    }
+
+    // Use "Templates" if it exists, but warn about non-canonical naming
+    if (upperCaseExists) {
+      console.warn("⚠️  Using non-canonical 'Templates/' folder – consider renaming to 'templates/'.");
+      return upperCaseTemplatesPath;
     }
 
     // Break if we've reached the root or max depth (as a safety measure)

--- a/packages/cli/src/lib/paths.ts
+++ b/packages/cli/src/lib/paths.ts
@@ -2,21 +2,29 @@ import { join, dirname } from "path";
 import { projectTemplatesDir, userTemplatesDir } from "./pathHelpers";
 
 export interface ScopePaths {
-  templates: string;   // folder
-  configFile: string;  // single file
+  templates: string; // folder
+  configFile: string; // single file
 }
 
 /** Pick project vs user locations. */
 export function resolveScope(user: boolean): ScopePaths {
   // project root = folder that would hold ./templates
-  const projRoot = (projectTemplatesDir()?.replace(/[\/\\]templates$/, "")) || process.cwd();
+  let projRoot = process.cwd();
+
+  try {
+    const templatesDir = projectTemplatesDir();
+    projRoot = templatesDir?.replace(/[\/\\]templates$/, "") || process.cwd();
+    if (templatesDir?.includes("Templates")) {
+      projRoot = templatesDir?.replace(/[\/\\]Templates$/, "") || process.cwd();
+    }
+  } catch (error) {
+    // If projectTemplatesDir throws because of duplicate directories,
+    // we'll use the current working directory as fallback
+    console.error(error instanceof Error ? error.message : String(error));
+  }
 
   return {
-    templates: user
-      ? join(userTemplatesDir()!, "templates")
-      : join(projRoot, "templates"),
-    configFile: user
-      ? join(dirname(userTemplatesDir()!), "config.json")
-      : join(projRoot, "work-journal.json"),
+    templates: user ? join(userTemplatesDir()!, "templates") : join(projRoot, "templates"),
+    configFile: user ? join(dirname(userTemplatesDir()!), "config.json") : join(projRoot, "work-journal.json"),
   };
-} 
+}


### PR DESCRIPTION
This PR implements the feature described in #41. Added case-insensitive lookup, warning for Templates/, error for duplicates. Closes #41