### PR TITLE
fix: handle PascalCase Templates folder correctly

### DIFF
--- a/.changeset/work-journal-patch-20250520-adad.md
+++ b/.changeset/work-journal-patch-20250520-adad.md
@@ -1,0 +1,5 @@
+---
+"work-journal": patch
+---
+
+Patch update

--- a/packages/cli/src/lib/__tests__/paths.test.ts
+++ b/packages/cli/src/lib/__tests__/paths.test.ts
@@ -48,4 +48,13 @@ describe("resolveScope", () => {
 
     process.cwd = originalCwd;
   });
+
+  it("should resolve project root correctly when Templates/ uses PascalCase", () => {
+    // simulate PascalCase projectTemplatesDir()
+    vi.mocked(projectTemplatesDir).mockReturnValue("/repo/DevJournal/Templates");
+
+    const scope = resolveScope(false);
+
+    expect(scope.configFile).toBe("/repo/DevJournal/work-journal.json");
+  });
 });

--- a/packages/cli/src/lib/paths.ts
+++ b/packages/cli/src/lib/paths.ts
@@ -2,21 +2,20 @@ import { join, dirname } from "path";
 import { projectTemplatesDir, userTemplatesDir } from "./pathHelpers";
 
 export interface ScopePaths {
-  templates: string;   // folder
-  configFile: string;  // single file
+  templates: string; // folder
+  configFile: string; // single file
 }
 
 /** Pick project vs user locations. */
 export function resolveScope(user: boolean): ScopePaths {
-  // project root = folder that would hold ./templates
-  const projRoot = (projectTemplatesDir()?.replace(/[\/\\]templates$/, "")) || process.cwd();
+  // project root = parent directory of the templates folder
+  const projTemplates = projectTemplatesDir(); // e.g. /path/DevJournal/Templates
+  const projRoot = projTemplates
+    ? dirname(projTemplates) //        /path/DevJournal
+    : process.cwd(); // fallback
 
   return {
-    templates: user
-      ? join(userTemplatesDir()!, "templates")
-      : join(projRoot, "templates"),
-    configFile: user
-      ? join(dirname(userTemplatesDir()!), "config.json")
-      : join(projRoot, "work-journal.json"),
+    templates: user ? join(userTemplatesDir()!, "templates") : join(projRoot, "templates"),
+    configFile: user ? join(dirname(userTemplatesDir()!), "config.json") : join(projRoot, "work-journal.json"),
   };
-} 
+}


### PR DESCRIPTION
This PR fixes issue #58 by replacing the case-sensitive regex with dirname() for more robust path handling. Changes: - Replace regex-based path manipulation with dirname() in resolveScope() - Add test case for PascalCase Templates folder - Create patch changeset. Testing: - All tests pass, including new PascalCase test case - Config files are now correctly placed in project root regardless of templates folder case. Closes #58