### PR TITLE
fix: warn once for non-canonical Templates folder

### DIFF
--- a/.changeset/work-journal-patch-20250520-113d.md
+++ b/.changeset/work-journal-patch-20250520-113d.md
@@ -1,0 +1,5 @@
+---
+"work-journal": patch
+---
+
+Warn once for non-canonical Templates folder

--- a/packages/cli/src/lib/pathHelpers.ts
+++ b/packages/cli/src/lib/pathHelpers.ts
@@ -3,6 +3,8 @@ import { join, dirname, parse, relative } from "path";
 import { existsSync, statSync, readdirSync } from "fs";
 import { fileURLToPath } from "url";
 
+let hasWarnedNonCanonical = false; // Module-level guard for warning
+
 export class DuplicateTemplatesError extends Error {
   code = "ERR_DUPLICATE_TEMPLATES_DIR";
   constructor() {
@@ -54,9 +56,12 @@ export function projectTemplatesDir(): string | null {
       if (pascalCaseExists) {
         // Include relative path in warning for better context
         const relativePath = relative(startDir, dir);
-        console.warn(
-          `⚠️  Using non-canonical 'Templates/' folder in ${relativePath} – consider renaming to 'templates/'.`
-        );
+        if (!hasWarnedNonCanonical) {
+          console.warn(
+            `⚠️  Using non-canonical 'Templates/' folder in ${relativePath} – consider renaming to 'templates/'.`
+          );
+          hasWarnedNonCanonical = true;
+        }
         return join(dir, "Templates");
       }
     } catch (error) {


### PR DESCRIPTION
This PR implements the fix for issue #57 to ensure the non-canonical Templates folder warning is only shown once per process. Changes: Added module-level guard variable, modified warning logic to only show once, all tests passing. Closes #57