### PR TITLE
refactor: use lowercase 'journal' directory instead of 'Journal'

### DIFF
--- a/.changeset/work-journal-major-20250520-025a.md
+++ b/.changeset/work-journal-major-20250520-025a.md
@@ -1,0 +1,5 @@
+---
+"work-journal": major
+---
+
+Change journal directory to lowercase for better filesystem compatibility

--- a/README.md
+++ b/README.md
@@ -257,3 +257,11 @@ npx husky add .husky/pre-push "pnpm test && npx markdownlint-cli2 ."
 ---
 
 Made with 💚 in Göteborg
+
+### 🗂️ Journal Structure
+
+The `new` command generates entries in a `journal/YYYY/MM/YYYY-MM-DD.md` structure. It creates this in your current working directory. If Work-Journal finds a `./templates/` directory or a `work-journal.json` config file by searching upwards from your current directory, it will use that discovered project root as the base for creating the `journal/` folder.
+
+> **Note:** If you have existing journal entries in a `Journal/` directory (capital J), you'll need to rename it to `journal/` (lowercase) to maintain compatibility with newer versions.
+
+### �� Templating Logic

--- a/packages/cli/src/commands/new.test.ts
+++ b/packages/cli/src/commands/new.test.ts
@@ -116,8 +116,9 @@ describe("new command", () => {
     // Run the command
     const journalPath = runNew(monday, false);
 
-    // Verify file was written with correct content
+    // Verify file was written with correct content and path
     expect(writtenFilePath).toBe(journalPath);
+    expect(writtenFilePath).toContain("journal/2025/05/2025-05-05.md");
     expect(writtenContent).toContain("Daily Template");
     expect(writtenContent).toContain("Top 3 priorities Daily");
     expect(writtenContent).not.toContain("<!-- TEMPLATE:");

--- a/packages/cli/src/commands/new.ts
+++ b/packages/cli/src/commands/new.ts
@@ -57,7 +57,7 @@ export function runNew(targetDate: Date, shouldOpen: boolean, force: boolean = f
   const quarter = Math.floor(targetDate.getMonth() / 3) + 1;
 
   // Build the journal file path
-  const journalDir = join(process.cwd(), "Journal", year, month);
+  const journalDir = join(process.cwd(), "journal", year, month);
   const journalFilePath = join(journalDir, `${dateString}.md`);
 
   // Create directory structure if needed


### PR DESCRIPTION
This PR implements #63. Changes: Changed journal directory to lowercase, updated README with migration note, updated tests. Breaking change: Users with existing 'Journal' directories need to rename them to 'journal'. Closes #63